### PR TITLE
Add attr_accessible for types so migrations work

### DIFF
--- a/app/models/calendar_event_type.rb
+++ b/app/models/calendar_event_type.rb
@@ -1,3 +1,4 @@
 class CalendarEventType < ActiveRecord::Base
   has_many :calendar_events
+  attr_accessible :name, :desc
 end


### PR DESCRIPTION
I was getting mass-assignment errors when running the initial migrations on Rails 3.2.  This fixes that.
